### PR TITLE
audiopolicy: Apply FM volume control parameter for MTK hardware too

### DIFF
--- a/services/audiopolicy/AudioPolicyManager.cpp
+++ b/services/audiopolicy/AudioPolicyManager.cpp
@@ -6918,7 +6918,7 @@ status_t AudioPolicyManager::checkAndSetVolume(audio_stream_type_t stream,
         // enabled
         if (stream == AUDIO_STREAM_BLUETOOTH_SCO) {
             mpClientInterface->setStreamVolume(AUDIO_STREAM_VOICE_CALL, volume, output, delayMs);
-#ifdef AUDIO_EXTN_FM_ENABLED
+#if defined(AUDIO_EXTN_FM_ENABLED) || defined(MTK_HARDWARE)
         } else if (stream == AUDIO_STREAM_MUSIC &&
                    output == mPrimaryOutput) {
             if (volume >= 0) {


### PR DESCRIPTION
MTK's audio uses the same parameter-based volume control for FM as QC,
so share it

Change-Id: I260cae9e85f2f668435746637a811c19ebc33857