### PR TITLE
audio: Fixed streamType for non-media streams

### DIFF
--- a/media/libmedia/AudioTrack.cpp
+++ b/media/libmedia/AudioTrack.cpp
@@ -400,7 +400,7 @@ status_t AudioTrack::set(
         memcpy(&mAttributes, pAttributes, sizeof(audio_attributes_t));
         ALOGV("Building AudioTrack with attributes: usage=%d content=%d flags=0x%x tags=[%s]",
                 mAttributes.usage, mAttributes.content_type, mAttributes.flags, mAttributes.tags);
-        mStreamType = audio_attributes_to_stream_type(&mAttributes);
+        mStreamType = AUDIO_STREAM_DEFAULT;
     }
 
     // these below should probably come from the audioFlinger too...


### PR DESCRIPTION
- When application passes attributes with non-media
  usage, it is wrongly converted to AUDIO_STREAM_MUSIC
  in AudioTrack and sent to AudioPolicyManager.
  This is causing wrong output to be selected by
  AudioPolicyManager. testTwoChannelCapturing is failed
  due to this reason

- Fix is to set mStreamType to be DEFAULT when
  attributes are passed by the client to AudioTrack

CRs-Fixed: 813683
Change-Id: Ibdb4859f9eb838b7b930e2509de1d98d62e1599d